### PR TITLE
fix: Env variables annotated with file is not allowed to be empty (#109)

### DIFF
--- a/env.go
+++ b/env.go
@@ -193,7 +193,7 @@ func get(field reflect.StructField) (val string, err error) {
 		return "", fmt.Errorf(`env: required environment variable %q is not set`, key)
 	}
 
-	if loadFile {
+	if loadFile && val != "" {
 		filename := val
 		val, err = getFromFile(filename)
 		if err != nil {


### PR DESCRIPTION
* adding support to overload env variable and load data from a file

* fixing file perm for TestFile

* refactoring in order to allow file option to act more in accoredence to prior setup

* adding more tests for file option and some extra for requierd option

* updating readme for env file tag

* refactoring to only load value from file if file annotation is given on tag

* updating readme for env file tag

* fixing formating

* fixing type-o

* Update env_test.go

Co-Authored-By: Carlos Alexandro Becker <caarlos0@users.noreply.github.com>

* Update env.go

Co-Authored-By: Carlos Alexandro Becker <caarlos0@users.noreply.github.com>

* lessening requierment for file annotation in order not to enforce that a file has to be given

Co-authored-by: Carlos Alexandro Becker <caarlos0@users.noreply.github.com>